### PR TITLE
Small changes and fixes

### DIFF
--- a/src/Geco/Common/SimpleMetadata/ForeignKey.cs
+++ b/src/Geco/Common/SimpleMetadata/ForeignKey.cs
@@ -29,7 +29,7 @@ namespace Geco.Common.SimpleMetadata
             this.ParentTable.ForeignKeys.GetWritable().Remove(this.Name);
             foreach (var fromColumn in FromColumns)
                 fromColumn.ForeignKey = this;
-            this.TargetTable.ForeignKeys.GetWritable().Remove(this.Name);
+            this.TargetTable.IncomingForeignKeys.GetWritable().Remove(this.Name);
         }
 
         private void OnFromColumnAdd(Column column)

--- a/src/Geco/Database/DatabaseCleaner.cs
+++ b/src/Geco/Database/DatabaseCleaner.cs
@@ -45,7 +45,7 @@ namespace Geco.Database
             CleanDatabase(connectionString);
         }
 
-        public static void CleanDatabase(string connectionString)
+        public void CleanDatabase(string connectionString)
         {
             using (var cnn = new SqlConnection(connectionString))
             {
@@ -54,7 +54,7 @@ namespace Geco.Database
                 {
                     foreach (var statement in Statements)
                     {
-                        using (var cmd = new SqlCommand(statement.ToString(), cnn, tran))
+                        using (var cmd = new SqlCommand(statement.ToString(), cnn, tran){CommandTimeout = options.CommandTimeout})
                         {
                             ColorConsole.WriteLine(("Running: ", Yellow), (string.Format(statement.Format, "", "***"), White));
                             cmd.ExecuteNonQuery();

--- a/src/Geco/Database/DatabaseCleanerOptions.cs
+++ b/src/Geco/Database/DatabaseCleanerOptions.cs
@@ -3,5 +3,6 @@
     public class DatabaseCleanerOptions
     {
         public string ConnectionName { get; set; }
+        public int CommandTimeout { get; set; } = 60;
     }
 }

--- a/src/Geco/Database/SeedDataGenerator.cs
+++ b/src/Geco/Database/SeedDataGenerator.cs
@@ -22,6 +22,8 @@ namespace Geco.Database
         private readonly Func<Column, bool> columnsFilter = c => !c.IsComputed;
         private readonly Func<Table, string> whereClause = _ => null;
         private readonly Func<Table, string> mergeFilter = _ => null;
+        private readonly Func<Table, string> orderByClause = t => string.Join(", ",
+            t.Indexes.First(i => i.IsClustered).Columns.Select(c => $"[{c.Name}]").ToArray());
 
         public SeedDataGenerator(SeedDataGeneratorOptions options, IMetadataProvider provider, IInflector inflector, IConfigurationRoot configurationRoot) : base(provider, inflector, options.ConnectionName)
         {
@@ -34,15 +36,21 @@ namespace Geco.Database
             if (options.Tables.Count == 0 && String.IsNullOrEmpty(options.TablesRegex) &&
                 options.ExcludedTables.Count == 0 && String.IsNullOrEmpty(options.ExcludedTablesRegex))
             {
-                ColorConsole.WriteLine($"No tables were selected. Use options Tables, TableRegex, ExcludedTables or ExcludedTablesRegex to specity the tables for which Seed data will be generated ", ConsoleColor.Red);
+                ColorConsole.WriteLine($"No tables were selected. Use options Tables, TableRegex, ExcludedTables or ExcludedTablesRegex to specify the tables for which Seed data will be generated ", ConsoleColor.Red);
                 return;
             }
 
             var tables = Db.Schemas.SelectMany(s => s.Tables)
                 .Where(t => (options.Tables.Any(n => Util.TableNameMaches(t, n))
-                || Util.TableNameMachesRegex(t, options.TablesRegex, true))
+                || Util.TableNameMachesRegex(t, options.TablesRegex, false))
                 && !options.ExcludedTables.Any(n => Util.TableNameMaches(t, n))
                 && !Util.TableNameMachesRegex(t, options.ExcludedTablesRegex, false)).OrderBy(t => t.Schema.Name + "." + t.Name).ToArray();
+
+            if (options.IgnoreColumns.Count > 0)
+                foreach (var tableColumn in tables.SelectMany(t => t.Columns)
+                    .Where(c => options.IgnoreColumns.Contains(c.Name)))
+                    tableColumn.GetWritable().Remove();
+
             TopologicalSort(tables);
             GenerateSeedFile(options.OutputFileName, tables);
 
@@ -66,7 +74,7 @@ namespace Geco.Database
         private void GenerateTableSeed(Table table, IEnumerable<IEnumerable<object>> rowValues)
         {
             var columns = table.Columns.Where(columnsFilter).ToList();
-            var rows = rowValues.WithInfo().ToList();
+            var rows = rowValues.ToList().WithInfo();
             if (!rows.Any())
                 return;
 
@@ -128,7 +136,8 @@ namespace Geco.Database
                     .Where(columnsFilter)
                     .ToList();
                 var where = whereClause(table);
-                cmd.CommandText = $"SELECT {CommaJoin(columns, ColumnExpression)} FROM [{table.Schema.Name}].[{table.Name}] WHERE {(String.IsNullOrEmpty(where) ? "1=1" : where)}";
+                var orderBy = orderByClause(table);
+                cmd.CommandText = $"SELECT {CommaJoin(columns, ColumnExpression)} FROM [{table.Schema.Name}].[{table.Name}] WHERE {(String.IsNullOrEmpty(where) ? "1=1" : where)} ORDER BY {orderBy}";
                 cnn.Open();
                 cmd.Connection = cnn;
                 using (var rdr = cmd.ExecuteReader())

--- a/src/Geco/Database/SeedDataGeneratorOptions.cs
+++ b/src/Geco/Database/SeedDataGeneratorOptions.cs
@@ -11,5 +11,6 @@ namespace Geco.Database
         public List<string> ExcludedTables { get; } = new List<string>();
         public string ExcludedTablesRegex { get; set; }
         public int ItemsPerStatement { get; set; } = 1000;
+        public List<string> IgnoreColumns { get; } = new List<string>();
     }
 }


### PR DESCRIPTION
Fixes:
- When removing a ForeignKey, remove the IncomingForeignKey from the TargetTable as well
- SeedDataGenerator: Order rows by clustered index if possible;

Features:
- DatabaseCleaner: Added Timeout parameter for DatabaseCleanerOptions (useful when run during builds or to identify strange situations when cleaning takes an abnormally long time.). Default: 60 seconds
- SeedDataGenerator: Added support for ignored columns;